### PR TITLE
Update cron.py

### DIFF
--- a/app/cron.py
+++ b/app/cron.py
@@ -45,10 +45,11 @@ def dict_news_task():
     with app.app_context():
         dict_config = models.KeyValue.query.filter_by(keyname=DICT_NEWS_KEY).first() or models.KeyValue(DICT_NEWS_KEY, "111")
         news_items = get_dict_news()
-        current_maxseen = 0
+        db_maxseen = int(dict_config.value)
+        current_maxseen = db_maxseen
         for news_item in get_dict_news():
             current_maxseen = max(current_maxseen, news_item['id'])
-            if news_item['id'] > int(dict_config.value):
+            if news_item['id'] > db_maxseen:
                 post_dict_news(news_item)
         dict_config.value = str(current_maxseen)
         db.session.add(dict_config)


### PR DESCRIPTION
don't update maxseen in db to 0 if the page failed to provide any news items
the previous code would sometimes reset dict_config.value to 0 if there were no news_items